### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,5 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-        tags: latest,1.20.15
+        tags: latest,1.21.14
         cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,5 @@ jobs:
         name: nickgronow/kubectl
         username: ${{ secrets.docker_username }}
         password: ${{ secrets.docker_password }}
-        tags: latest,1.17.4
+        tags: latest,1.19.13
         cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,5 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-        tags: latest,1.22.16
+        tags: latest,1.23.15
         cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - uses: elgohr/Publish-Docker-Github-Action@master
+    - uses: elgohr/Publish-Docker-Github-Action@v4
       name: Publish to Docker
       with:
-        name: nickgronow/kubectl
-        username: ${{ secrets.docker_username }}
-        password: ${{ secrets.docker_password }}
+        name: innovaciongascaribe/kubectl
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
         tags: latest,1.20.15
         cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,5 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-        tags: latest,1.21.14
+        tags: latest,1.22.16
         cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,5 @@ jobs:
         name: nickgronow/kubectl
         username: ${{ secrets.docker_username }}
         password: ${{ secrets.docker_password }}
-        tags: latest,1.19.13
+        tags: latest,1.20.15
         cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - uses: elgohr/Publish-Docker-Github-Action@v4
+    - uses: elgohr/Publish-Docker-Github-Action@v5
       name: Publish to Docker
       with:
         name: innovaciongascaribe/kubectl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/kubectl:1.20.15
+FROM bitnami/kubectl:1.21.14
 
 LABEL version="1.0.2"
 LABEL name="kubectl"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,4 @@ COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["help"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/kubectl:1.22.16
+FROM bitnami/kubectl:1.23.15
 
 LABEL version="1.0.2"
 LABEL name="kubectl"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/kubectl:1.19.13
+FROM bitnami/kubectl:1.20.15
 
 LABEL version="1.0.2"
 LABEL name="kubectl"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/kubectl:1.21.14
+FROM bitnami/kubectl:1.22.16
 
 LABEL version="1.0.2"
 LABEL name="kubectl"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM bitnami/kubectl:1.17.4
+FROM bitnami/kubectl:1.19.13
 
-LABEL version="1.0.1"
+LABEL version="1.0.2"
 LABEL name="kubectl"
 LABEL repository="http://github.com/nickgronow/kubectl"
 LABEL homepage="http://github.com/nickgronow/kubectl"

--- a/action.yml
+++ b/action.yml
@@ -10,4 +10,4 @@ inputs:
     required: true
 runs:
   using: docker
-  image: docker://ghcr.io/innovaciongascaribe/kubectl:1.20.15
+  image: docker://ghcr.io/innovaciongascaribe/kubectl:1.21.14

--- a/action.yml
+++ b/action.yml
@@ -10,4 +10,4 @@ inputs:
     required: true
 runs:
   using: docker
-  image: docker://ghcr.io/innovaciongascaribe/kubectl:1.21.14
+  image: docker://ghcr.io/innovaciongascaribe/kubectl:1.22.16

--- a/action.yml
+++ b/action.yml
@@ -10,4 +10,4 @@ inputs:
     required: true
 runs:
   using: docker
-  image: docker://ghcr.io/innovaciongascaribe/kubectl:1.22.16
+  image: docker://ghcr.io/innovaciongascaribe/kubectl:1.23.15

--- a/action.yml
+++ b/action.yml
@@ -10,4 +10,4 @@ inputs:
     required: true
 runs:
   using: docker
-  image: docker://nickgronow/kubectl:1.17
+  image: docker://ghcr.io/innovaciongascaribe/kubectl:1.19.13

--- a/action.yml
+++ b/action.yml
@@ -10,4 +10,4 @@ inputs:
     required: true
 runs:
   using: docker
-  image: docker://ghcr.io/innovaciongascaribe/kubectl:1.19.13
+  image: docker://ghcr.io/innovaciongascaribe/kubectl:1.20.15


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore